### PR TITLE
Allow access of networking.k8s.io/ingresses to kube-state-metrics

### DIFF
--- a/helm-chart/templates/metrics-exporter/kube-state-metrics-clusterrole.yaml
+++ b/helm-chart/templates/metrics-exporter/kube-state-metrics-clusterrole.yaml
@@ -2,6 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+
   name: vessl-kube-state-metrics-{{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -12,6 +16,7 @@ rules:
     - nodes
     - pods
     - services
+    - serviceaccounts
     - resourcequotas
     - replicationcontrollers
     - limitranges
@@ -103,6 +108,7 @@ rules:
     - networking.k8s.io
     resources:
     - networkpolicies
+    - ingresses
     verbs:
     - list
     - watch
@@ -110,6 +116,16 @@ rules:
     - coordination.k8s.io
     resources:
     - leases
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
     verbs:
     - list
     - watch


### PR DESCRIPTION
1.19 버전부터 ingress가 networking.k8s.io/v1 apiGroup 아래로 이동했고, 1.22부터 deprecation이 일어났습니다. 1.23을 쓰고 있는 지금 기존의 clusterRole이 더이상 작동하지 않아 패치합니다.

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#what-to-do