### PR TITLE
Only Set DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE when the value is given from chart

### DIFF
--- a/helm-chart/templates/metrics-exporter/dcgm-exporter-daemonset.yaml
+++ b/helm-chart/templates/metrics-exporter/dcgm-exporter-daemonset.yaml
@@ -30,10 +30,10 @@ spec:
           value: ':9400'
         - name: DCGM_EXPORTER_KUBERNETES
           value: 'true'
+        {{ if .Values.metricsExporters.dcgmExporter.useDeviceName }}
         - name: DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE
-          {{ if .Values.metricsExporters.dcgmExporter.useDeviceName }}
           value: {{ .Values.metricsExporters.dcgmExporter.useDeviceName }}
-          {{ end }}
+        {{ end }}
         name: dcgm-exporter
         ports:
         - name: metrics


### PR DESCRIPTION
현재 차트 구조는 일단 env DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE를 주고 마땅한 value가 없으면 '' (empty string) 을 넣어버리는데, dcgm exporter는 모르는 값이므로 아래와 같이 뻗어버립니다.
```
Failed to transform metrics for transorm unsupported KubernetesGPUIDType for MetricID ''
```

chart value `.Values.metricsExporters.dcgmExporter.useDeviceName` 가 없거나 empty라면 아예 해당 envvar를 주지 않게 해야 합니다. 기본값에 대한 처리는 dcgm exporter binary가 [UUID로 잘 넣어주고](https://github.com/NVIDIA/dcgm-exporter/blob/d40847d147eb8da211c5fec4c9c840729053eab7/cmd/dcgm-exporter/main.go#L141-L147) 있습니다. 