### PR TITLE
VSSL-4535 Add relabel config about kube-state-metrics

### DIFF
--- a/helm-chart/templates/metrics-exporter/kube-state-metrics-deployment.yaml
+++ b/helm-chart/templates/metrics-exporter/kube-state-metrics-deployment.yaml
@@ -27,6 +27,8 @@ spec:
       containers:
       - name: kube-state-metrics
         image: {{ template "vessl.image.source" . -}}/kube-state-metrics:{{- .Values.metricsExporters.kubeStateMetrics.imageVersion }}
+        args:
+        - --metric-labels-allowlist=pods=[*],deployments=[*],statefulsets=[*],jobs=[*],daemonsets=[*]
         ports:
         - name: metrics
           containerPort: 8080

--- a/helm-chart/templates/prometheus/servicemonitor.yaml
+++ b/helm-chart/templates/prometheus/servicemonitor.yaml
@@ -53,6 +53,13 @@ spec:
       action: replace
     - regex: '^instance$'
       action: labeldrop
+    - action: labelkeep
+      regex: ^(pod|namespace|(.*)_vessl_ai_(.*)|__(.+)__)$
+    - action: labelmap
+      regex: label_(.+)_k8s_vessl_ai_(.+)
+      replacement: '${1}_k8s_vessl_ai_${2}'
+    - action: labeldrop
+      regex: label_(.*)
     relabelings:
     - regex: feature_node_kubernetes_io_(.+)
       action: labeldrop


### PR DESCRIPTION
- [x] kube-state-metrics 옵션 추가 / pod, deployment, statefulset, daemonset label을 다 수집합니다.
```
kube_pod_labels{namespace="erhkefmv8pmi", pod="model-service-revision-yyv4xjngk4eu-75545d4f4d-5vbqr", v1_k8s_vessl_ai_logs_enabled="true", v1_k8s_vessl_ai_managed="true", v1_k8s_vessl_ai_model_service_partition="2be75ca0b514", v1_k8s_vessl_ai_partition="yyv4xjngk4eu", v1_k8s_vessl_ai_revision_number="2", v1_k8s_vessl_ai_system_metrics_enabled="true", v1_k8s_vessl_ai_type="model-service-revision"}
```
- [x] kube-state-metrics service monitor 설정 변경 / kube_*_label 메트릭 중 v1_k8s_vessl_ai_*애 대한 레이블만 남기고 나머지는 버립니다.