### PR TITLE
VSSL-4448 Add ServiceMonitor to scrape revision metrcis

### DIFF
--- a/helm-chart/templates/prometheus/servicemonitor.yaml
+++ b/helm-chart/templates/prometheus/servicemonitor.yaml
@@ -126,5 +126,5 @@ spec:
     any: true
   selector:
     matchLabels:
-      v1.k8s.vessl.ai/type: model-service-revision-exporter
+      v1.k8s.vessl.ai/serving-metrics-enabled: true
 {{- end -}}

--- a/helm-chart/templates/prometheus/servicemonitor.yaml
+++ b/helm-chart/templates/prometheus/servicemonitor.yaml
@@ -110,7 +110,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    prometheus: vessl-prometheu
+    prometheus: vessl-prometheus
   name: vessl-model-service-servicemonitor
 spec:
   endpoints:

--- a/helm-chart/templates/prometheus/servicemonitor.yaml
+++ b/helm-chart/templates/prometheus/servicemonitor.yaml
@@ -105,4 +105,26 @@ spec:
   selector:
     matchLabels:
       v1.k8s.vessl.ai/type: node-exporter
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    prometheus: vessl-prometheu
+  name: vessl-model-service-servicemonitor
+spec:
+  endpoints:
+  - path: /metrics
+    port: metrics
+    honorLabels: true
+    metricRelabelings:
+    - sourceLabels:
+        - __name__
+      regex: '(bentoml_(.+)|BENTOML_(.+)|nv_(.+)|)' # bentoml, BENTOML are offered by bento, nv is offered by triton-inference-server, 
+      action: keep
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      v1.k8s.vessl.ai/type: model-service-revision-exporter
 {{- end -}}


### PR DESCRIPTION
- [x] bentoml 메트릭 수집 추가
- [x] triton 메트릭 수집 추가
- [ ] ~~seldon 메트릭 수집 추가 (seldon은 endpoint가 /prometheus이기 때문에 이번 PR&마일스톤에서는 제외)~~
- [ ] ~~truss 메트릭 수집 추가 (별다른 메트릭 문서가 없음, 직접 띄어봐야 알 수 있을 것으로 보입니다.)~~