### PR TITLE
VSSL-5215: Do not drop kube_pod_labels on kube-state-metrics-servicemonitor

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cluster-resources
-version: 0.1.41
+version: 0.1.42
 dependencies:
 - name: kube-prometheus-stack
   version: "39.10.0"

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -2,6 +2,9 @@
 
 ## Release Notes
 
+### v0.1.42 (2023-06-01)
+- Do not drop `kube_pod_labels` on kube-state-metrics-servicemonitor
+
 ### v0.1.41 (2023-05-31)
 - Fix ServiceMonitor using non-string value for `matchLabels` field
 

--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -2,6 +2,27 @@ apiVersion: v1
 entries:
   cluster-resources:
   - apiVersion: v2
+    created: "2023-06-01T10:12:23.958868+09:00"
+    dependencies:
+    - condition: prometheus.enabled
+      name: kube-prometheus-stack
+      repository: https://prometheus-community.github.io/helm-charts
+      version: 39.10.0
+    - condition: nvidia-device-plugin.enabled
+      name: nvidia-device-plugin
+      repository: https://nvidia.github.io/k8s-device-plugin
+      version: 0.12.3
+    - alias: nfd
+      condition: nfd.enabled
+      name: node-feature-discovery
+      repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      version: 0.11.0
+    digest: 53376d53997f864eeee2a7d13344f65b78bd1eed0063a53c4ab6919fc139a4d2
+    name: cluster-resources
+    urls:
+    - https://vessl-helm-packages.s3.ap-northeast-2.amazonaws.com/cluster-resources/cluster-resources-0.1.42.tgz
+    version: 0.1.42
+  - apiVersion: v2
     created: "2023-05-31T10:21:46.254529+09:00"
     dependencies:
     - condition: prometheus.enabled
@@ -514,7 +535,7 @@ entries:
       artifacthub.io/operator: "true"
     apiVersion: v2
     appVersion: 0.58.0
-    created: "2023-05-31T10:21:46.265065+09:00"
+    created: "2023-06-01T10:12:23.969604+09:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -566,7 +587,7 @@ entries:
   node-feature-discovery:
   - apiVersion: v2
     appVersion: v0.11.0
-    created: "2023-05-31T10:21:46.265542+09:00"
+    created: "2023-06-01T10:12:23.970271+09:00"
     description: 'Detects hardware features available on each node in a Kubernetes
       cluster, and advertises those features using node labels. '
     digest: 76622631aeb287b26f4c57ca5d3f8ab76571bbb1473b276227bf769cb40b9318
@@ -585,7 +606,7 @@ entries:
   nvidia-device-plugin:
   - apiVersion: v2
     appVersion: 0.12.3
-    created: "2023-05-31T10:21:46.266331+09:00"
+    created: "2023-06-01T10:12:23.971203+09:00"
     dependencies:
     - alias: nfd
       condition: nfd.enabled,gfd.enabled
@@ -606,4 +627,4 @@ entries:
     urls:
     - https://vessl-helm-packages.s3.ap-northeast-2.amazonaws.com/cluster-resources/charts/nvidia-device-plugin-0.12.3.tgz
     version: 0.12.3
-generated: "2023-05-31T10:21:46.239963+09:00"
+generated: "2023-06-01T10:12:23.94538+09:00"

--- a/helm-chart/templates/prometheus/servicemonitor.yaml
+++ b/helm-chart/templates/prometheus/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     metricRelabelings:
     - sourceLabels:
         - __name__
-      regex: '(kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_node_status_capacity|kube_node_status_allocatable|kube_persistentvolume_(.+)|kube_persistentvolumeclaim_(.+)|kube_pod_status_phase|kube_pod_info)'
+      regex: '(kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_labels|kube_node_status_capacity|kube_node_status_allocatable|kube_persistentvolume_(.+)|kube_persistentvolumeclaim_(.+)|kube_pod_status_phase|kube_pod_info)'
       action: keep
     - sourceLabels: [node]
       separator: ;


### PR DESCRIPTION
VSSL-5215에서 지적된 문제를 수정합니다.