### PR TITLE
Fix no results with grep terminates whole script

### DIFF
--- a/tools/bootstrap-cluster/bootstrap-cluster.sh
+++ b/tools/bootstrap-cluster/bootstrap-cluster.sh
@@ -240,7 +240,7 @@ ensure_nvidia_gpu_dependencies() {
 
   install_nvidia_fabricmanager=false
   for model in "${models[@]}"; do
-    gpu_count=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | grep -c "$model")
+    gpu_count=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | grep -c "$model" || true)
     if [ "$gpu_count" -gt 1 ]; then
       install_nvidia_fabricmanager=true
       break


### PR DESCRIPTION
`set -eo pipefail`에 의해 grep에서 아무것도 잡히지 않으면 않으면 non-zero exit code가 나와 전체 스크립트가 중단되는 문제를 수정합니다.