### PR TITLE
Add kubelet-extra-args for cgroup-driver.

### DIFF
--- a/tools/bootstrap-cluster/bootstrap-cluster.sh
+++ b/tools/bootstrap-cluster/bootstrap-cluster.sh
@@ -387,9 +387,9 @@ run_k0s_worker_daemon() {
 
   sudo $K0S_EXECUTABLE install worker \
     --token-file $K0S_CONFIG_PATH/token \
-    --kubelet-extra-args --cgroup-driver=systemd \
     $CRI_SOCKET_OPTION \
-    --enable-cloud-provider
+    --enable-cloud-provider \
+    --kubelet-extra-args=--cgroup-driver=systemd
 
   bold "Starting k0sworker.service"
   sudo $K0S_EXECUTABLE start

--- a/tools/bootstrap-cluster/bootstrap-cluster.sh
+++ b/tools/bootstrap-cluster/bootstrap-cluster.sh
@@ -387,6 +387,7 @@ run_k0s_worker_daemon() {
 
   sudo $K0S_EXECUTABLE install worker \
     --token-file $K0S_CONFIG_PATH/token \
+    --kubelet-extra-args --cgroup-driver=systemd \
     $CRI_SOCKET_OPTION \
     --enable-cloud-provider
 

--- a/tools/bootstrap-cluster/bootstrap-cluster.sh
+++ b/tools/bootstrap-cluster/bootstrap-cluster.sh
@@ -389,7 +389,7 @@ run_k0s_worker_daemon() {
     --token-file $K0S_CONFIG_PATH/token \
     $CRI_SOCKET_OPTION \
     --enable-cloud-provider \
-    --kubelet-extra-args=--cgroup-driver=systemd
+    --kubelet-extra-args="--cgroup-driver=systemd"
 
   bold "Starting k0sworker.service"
   sudo $K0S_EXECUTABLE start


### PR DESCRIPTION
https://github.com/vessl-ai/cluster-resources/commit/9b377713f3a27dabdd074592046298a5e9f46ab6

해당 PR에서 사라졌던 kubelet cgroup driver 설정을 다시 집어넣습니다.